### PR TITLE
use List::SomeUtils for first/lastidx instead of List::MoreUtils

### DIFF
--- a/modules/Test-Run-Plugin-TrimDisplayedFilenames/Build.PL
+++ b/modules/Test-Run-Plugin-TrimDisplayedFilenames/Build.PL
@@ -25,6 +25,7 @@ my $builder = Test::Run::Builder->new(
         'Test::Run::Core' => "0.0122",
         'MRO::Compat' => 0,
         'Moose' => 0,
+        'List::SomeUtils' => 0,
     },
     test_requires => {
         'YAML::XS' => 0,

--- a/modules/Test-Run-Plugin-TrimDisplayedFilenames/lib/Test/Run/Plugin/TrimDisplayedFilenames.pm
+++ b/modules/Test-Run-Plugin-TrimDisplayedFilenames/lib/Test/Run/Plugin/TrimDisplayedFilenames.pm
@@ -10,7 +10,7 @@ use Moose;
 use MRO::Compat;
 use File::Spec ();
 use File::Basename qw/ basename dirname /;
-use List::MoreUtils ();
+use List::SomeUtils ();
 
 extends('Test::Run::Base');
 
@@ -60,8 +60,8 @@ sub _get_search_from_callback
     my ( $self, $options ) = @_;
 
     return +( $options->{search_from} eq "start" )
-        ? \&List::MoreUtils::firstidx
-        : \&List::MoreUtils::lasttidx;
+        ? \&List::SomeUtils::firstidx
+        : \&List::SomeUtils::lasttidx;
 }
 
 sub _get_array_portion


### PR DESCRIPTION
Suggestion: use `List::SomeUtils` instead of `List::MoreUtils` for `firstidx` and `lastidx`.

I noticed when working on #1 that List::MoreUtils is used here undeclared, but probably hasn't been a problem yet since `Test::Run` requires it?  Anyway, I would recommend explicitly requiring and using `List::SomeUtils` instead as its install process is less complicated.